### PR TITLE
Added java resources

### DIFF
--- a/programming/java-resources.md
+++ b/programming/java-resources.md
@@ -1,0 +1,29 @@
+# Java Resources
+*go back to [/r/FTC wiki](/r/FTC/wiki)*
+
+__This article is up to date as of Nov 30, 2017.__
+
+## Java Language
+
+### Learning Java
+Learning Source|Description
+:---------------------:|:-------------------------------------------
+University of Helsinki - Object Oriented programming with Java|An open course written by the Department of Computer Science at the University of Helsinki. This course will guide you through most of what you need to know for java programming in FTC. In addition, there is a part 2 to the course which introduces more advanced concepts. What set's this course apart from others is its "Test My Code" service, which allows you to submit solutions to the problems to be auto checked; so, if you mess up, you will know. The cons are that it can be somewhat reptitive with it's excersizes, and you will be required to do most of them.
+AP Computer Science Review Books|You don't have to be taking AP Computer Science to use the review books. Review books are highly condensed and cover the entirety of the AP curriculum, which includes topics which are neccesary for a good robot, such as inheritance and true object oriented programming. There are many books; the three most common ones are Barron's, Princeton Review, and 5 Steps to a Five. Barron's will have the best learning material of the 3. Princeton Review and 5 Steps to a Five are more problem based.
+
+### Programming Practice
+Succeding in FTC requires one to have experience with the java language. There are a multitude of websites which can allow one to practice various skills.
+
+While not all of these sites are strictly for Java, they are still valuable for providing questions and getting your feet wet with the language. 
+
+Additionally, you can use most of these websites for any language - so if you're interseted in learning another language, you can use this as well.
+
+Website|Description
+:---------:|:------------------------------------------------------------------
+[Project Euler](https://projecteuler.net/about)|Project Euler is a website which focuses around programming questions related to math. The lower number questions are great for farmiliarizing oneself with a language and it's syntax, while higher numbered problems help with algorithm creation, as one begins to have to worry about the speed of your solution. This is a great way to learn some more difficult aspects of programming (which can be incorporated into your FTC programs), along with some math.
+[CodingBat](http://codingbat.com/java)|CodingBat is a good way to learn some basics of java, including basic syntax, logic, strings, arrays, and recursion, along with some aspects of functional programming. A good way to practice basics of a language
+
+
+
+*All content on this wiki is licensed under the [Creative Commons Attribution-ShareAlike 4.0](https://creativecommons.org/licenses/by-sa/4.0/) liscense.*
+/r/FTC thanks you for reading this article and asks you to [contribute](https://github.com/GeekyStudios/rFTC-wiki) soon.

--- a/programming/java-resources.md
+++ b/programming/java-resources.md
@@ -8,15 +8,15 @@ __This article is up to date as of Nov 30, 2017.__
 ### Learning Java
 Learning Source|Description
 :---------------------:|:-------------------------------------------
-University of Helsinki - Object Oriented programming with Java|An open course written by the Department of Computer Science at the University of Helsinki. This course will guide you through most of what you need to know for java programming in FTC. In addition, there is a part 2 to the course which introduces more advanced concepts. What set's this course apart from others is its "Test My Code" service, which allows you to submit solutions to the problems to be auto checked; so, if you mess up, you will know. The cons are that it can be somewhat reptitive with it's excersizes, and you will be required to do most of them.
+[University of Helsinki - Object Oriented programming with Java](http://mooc.fi/courses/2013/programming-part-1/)|An open course written by the Department of Computer Science at the University of Helsinki. This course will guide you through most of what you need to know for java programming in FTC. In addition, there is a part 2 to the course which introduces more advanced concepts. What set's this course apart from others is its "Test My Code" service, which allows you to submit solutions to the problems to be auto checked; so, if you mess up, you will know. The cons are that it can be somewhat reptitive with it's excersizes, and you will be required to do most of them.
 AP Computer Science Review Books|You don't have to be taking AP Computer Science to use the review books. Review books are highly condensed and cover the entirety of the AP curriculum, which includes topics which are neccesary for a good robot, such as inheritance and true object oriented programming. There are many books; the three most common ones are Barron's, Princeton Review, and 5 Steps to a Five. Barron's will have the best learning material of the 3. Princeton Review and 5 Steps to a Five are more problem based.
 
 ### Programming Practice
-Succeding in FTC requires one to have experience with the java language. There are a multitude of websites which can allow one to practice various skills.
+Succeding in FTC requires one to have experience with the java language, experience which can't be taught. There are a multitude of websites which can allow one to practice various skills.
 
-While not all of these sites are strictly for Java, they are still valuable for providing questions and getting your feet wet with the language. 
+While not all of these sites are strictly for Java, they are still valuable for providing questions and getting your feet wet with the language.
 
-Additionally, you can use most of these websites for any language - so if you're interseted in learning another language, you can use this as well.
+Additionally, you can use most of these websites for any language - so if you're interested in learning another language, you can use this as well.
 
 Website|Description
 :---------:|:------------------------------------------------------------------


### PR DESCRIPTION
What I did in these commits:

1. Renamed `java-tutorials.md` to `java-resources.md`
2. Added some resources I found useful, with description

I renamed `java-tutorials.md` to `java-resources.md` because I felt that it made more sense, since programming isn't just taught with tutorials. It also is more open ended, so we can get more useful links and stuff.

The 4 resources I added are resources I used and thought were useful. 

I did not mention the ability to find many AP review books online as PDFs, not sure if we want that in the wiki since it is a bit of a gray area. A comment indicating the availability can be added if it's agreed it should be in the wiki. I think it should.

I checked the formatting for a reddit wiki and it looked fine.

Eventually we will want more resources. I think we could add various git repositories of teams which have open source code, as a sort of learn by example, in addition to other websites/books.